### PR TITLE
Fix entry_type

### DIFF
--- a/custom_components/aladin_online/sensor.py
+++ b/custom_components/aladin_online/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.helpers.device_registry import DeviceEntryType
 from types import MappingProxyType
 from typing import Final
 from .aladin_online import AladinActualWeather
@@ -104,7 +105,7 @@ DEVICE_INFO: Final[DeviceInfo] = {
 	"model": "Weather forecast",
 	"default_name": "Weather forecast",
 	"manufacturer": NAME,
-	"entry_type": "service",
+	"entry_type": DeviceEntryType.SERVICE,
 }
 
 async def async_setup_entry(hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry, async_add_entities) -> None:

--- a/custom_components/aladin_online/weather.py
+++ b/custom_components/aladin_online/weather.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
+from homeassistant.helpers.device_registry import DeviceEntryType
 from types import MappingProxyType
 from typing import Final
 from .aladin_online import AladinActualWeather
@@ -30,7 +31,7 @@ DEVICE_INFO: Final[DeviceInfo] = {
 	"model": "Weather forecast",
 	"default_name": "Weather forecast",
 	"manufacturer": NAME,
-	"entry_type": "service",
+	"entry_type": DeviceEntryType.SERVICE,
 }
 
 


### PR DESCRIPTION
Fixes warnings:
Detected code that uses str for device registry entry_type. This is deprecated and will stop working in Home Assistant 2022.3, it should be updated to use DeviceEntryType instead. Please report this issue.