### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/aladin_online/sensor.py
+++ b/custom_components/aladin_online/sensor.py
@@ -137,6 +137,8 @@ class SensorEntity(CoordinatorEntity, ComponentSensorEntity):
 
 	_attr_has_entity_name = True
 
+	_attr_name = None
+
 	def __init__(self, coordinator: DataUpdateCoordinator, config: MappingProxyType, entity_description: SensorEntityDescription):
 		super().__init__(coordinator)
 


### PR DESCRIPTION
To avoid WARNING in HASS:

`WARNING (MainThread) [homeassistant.helpers.entity] Entity None (<class 'custom_components.aladin_online.sensor.SensorEntity'>) is implicitly using device name by not setting its name. Instead, the name should be set to None, please report it to the custom integration author.`