### PR TITLE
Fix wind_bearing field

### DIFF
--- a/custom_components/aladin_online/aladin_online.py
+++ b/custom_components/aladin_online/aladin_online.py
@@ -257,4 +257,4 @@ class AladinOnlineCoordinator(DataUpdateCoordinator):
 
 	@staticmethod
 	def _format_wind_direction(raw: float) -> float:
-		return raw / 100
+		return (raw + 180) % 360


### PR DESCRIPTION
Na zaklade dokumentace by mela byt hodnota klasicke stupne, pokud to chapu spravne. Podle dat z API to vypada, ze by to mohlo sedet.

```
The current wind bearing in azimuth angle (degrees) or 1-3 letter cardinal direction.
```

https://developers.home-assistant.io/docs/core/entity/weather/

A nasledne uprava hodnoty https://github.com/vrana/windy-plugin-aladin/blob/0cd728019f824ef41f8817335050761ae0870d5c/src/plugin.html#L42

<img width="607" alt="Snímek obrazovky 2023-10-16 v 6 47 02" src="https://github.com/kukulich/home-assistant-aladin-online/assets/3849376/b915175e-b840-4ed0-8aff-9d26e817eaa7">
