### PR TITLE
Fix: migrate to new ČHMÚ API endpoint (data-provider.chmi.cz)

### DIFF
--- a/custom_components/aladin_online/aladin_online.py
+++ b/custom_components/aladin_online/aladin_online.py
@@ -1,18 +1,18 @@
 from datetime import datetime, timedelta
 from homeassistant import core
 from homeassistant.components.weather import (
-    ATTR_CONDITION_CLEAR_NIGHT,
-    ATTR_CONDITION_CLOUDY,
-    ATTR_CONDITION_PARTLYCLOUDY,
-    ATTR_CONDITION_POURING,
-    ATTR_CONDITION_SNOWY,
-    ATTR_CONDITION_SUNNY,
-    ATTR_CONDITION_RAINY,
-    ATTR_CONDITION_WINDY,
+	ATTR_CONDITION_CLEAR_NIGHT,
+	ATTR_CONDITION_CLOUDY,
+	ATTR_CONDITION_PARTLYCLOUDY,
+	ATTR_CONDITION_POURING,
+	ATTR_CONDITION_SNOWY,
+	ATTR_CONDITION_SUNNY,
+	ATTR_CONDITION_RAINY,
+	ATTR_CONDITION_WINDY,
 )
 from homeassistant.const import (
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
+	CONF_LATITUDE,
+	CONF_LONGITUDE,
 )
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -20,10 +20,10 @@ from homeassistant.util import dt
 from http import HTTPStatus
 import math
 from .const import (
-    DOMAIN,
-    LOGGER,
-    CONF_STATION_ID,
-    URL,
+	DOMAIN,
+	LOGGER,
+	CONF_STATION_ID,
+	URL,
 )
 from .errors import NoData, ServiceUnavailable
 from types import MappingProxyType
@@ -37,193 +37,193 @@ URL: Final = "https://data-provider.chmi.cz/api/graphs/graf.meteogram/{}"
 # 40=polojasno, 140=polojasno noc, 60=skoro zataženo, 70=zataženo+déšť
 # 80=zataženo, 81=zataženo+déšť, 160=polojasno noc, 170=skoro zataženo noc
 ICON_CONDITION_MAP = {
-    10:  ATTR_CONDITION_SUNNY,          # jasno den
-    20:  ATTR_CONDITION_SUNNY,          # skoro jasno den
-    40:  ATTR_CONDITION_PARTLYCLOUDY,   # polojasno
-    60:  ATTR_CONDITION_CLOUDY,         # skoro zataženo
-    70:  ATTR_CONDITION_RAINY,          # zataženo + déšť
-    80:  ATTR_CONDITION_CLOUDY,         # zataženo
-    81:  ATTR_CONDITION_POURING,        # zataženo + silný déšť
-    110: ATTR_CONDITION_CLEAR_NIGHT,    # jasno noc
-    120: ATTR_CONDITION_CLEAR_NIGHT,    # skoro jasno noc
-    140: ATTR_CONDITION_PARTLYCLOUDY,   # polojasno noc
-    160: ATTR_CONDITION_PARTLYCLOUDY,   # skoro zataženo noc
-    170: ATTR_CONDITION_CLOUDY,         # zataženo noc
+	10:  ATTR_CONDITION_SUNNY,          # jasno den
+	20:  ATTR_CONDITION_SUNNY,          # skoro jasno den
+	40:  ATTR_CONDITION_PARTLYCLOUDY,   # polojasno
+	60:  ATTR_CONDITION_CLOUDY,         # skoro zataženo
+	70:  ATTR_CONDITION_RAINY,          # zataženo + déšť
+	80:  ATTR_CONDITION_CLOUDY,         # zataženo
+	81:  ATTR_CONDITION_POURING,        # zataženo + silný déšť
+	110: ATTR_CONDITION_CLEAR_NIGHT,    # jasno noc
+	120: ATTR_CONDITION_CLEAR_NIGHT,    # skoro jasno noc
+	140: ATTR_CONDITION_PARTLYCLOUDY,   # polojasno noc
+	160: ATTR_CONDITION_PARTLYCLOUDY,   # skoro zataženo noc
+	170: ATTR_CONDITION_CLOUDY,         # zataženo noc
 }
 
 
 class AladinActualWeather:
 
-    def __init__(
-        self,
-        condition: str,
-        temperature: float,
-        apparent_temperature: float,
-        precipitation: float,
-        pressure: float,
-        humidity: float,
-        clouds: float,
-        wind_speed: float,
-        wind_bearing: float,
-        wind_gust_speed: float,
-        wind_gust_bearing: float,
-        snow_precipitation: float,
-    ) -> None:
-        self.condition = condition
-        self.temperature = temperature
-        self.apparent_temperature = apparent_temperature
-        self.precipitation = precipitation
-        self.pressure = pressure
-        self.humidity = humidity
-        self.clouds = clouds
-        self.wind_speed = wind_speed
-        self.wind_bearing = wind_bearing
-        self.wind_gust_speed = wind_gust_speed
-        self.wind_gust_bearing = wind_gust_bearing
-        self.snow_precipitation = snow_precipitation
+	def __init__(
+		self,
+		condition: str,
+		temperature: float,
+		apparent_temperature: float,
+		precipitation: float,
+		pressure: float,
+		humidity: float,
+		clouds: float,
+		wind_speed: float,
+		wind_bearing: float,
+		wind_gust_speed: float,
+		wind_gust_bearing: float,
+		snow_precipitation: float,
+	) -> None:
+		self.condition = condition
+		self.temperature = temperature
+		self.apparent_temperature = apparent_temperature
+		self.precipitation = precipitation
+		self.pressure = pressure
+		self.humidity = humidity
+		self.clouds = clouds
+		self.wind_speed = wind_speed
+		self.wind_bearing = wind_bearing
+		self.wind_gust_speed = wind_gust_speed
+		self.wind_gust_bearing = wind_gust_bearing
+		self.snow_precipitation = snow_precipitation
 
 
 class AladinWeatherForecast:
 
-    def __init__(
-        self,
-        forecast_datetime: datetime,
-        condition: str,
-        temperature: float,
-        apparent_temperature: float,
-        precipitation: float,
-        pressure: float,
-        wind_speed: float,
-        wind_bearing: float,
-        wind_gust_speed: float,
-        humidity: float,
-        clouds: float,
-    ) -> None:
-        self.datetime = forecast_datetime
-        self.condition = condition
-        self.temperature = temperature
-        self.apparent_temperature = apparent_temperature
-        self.precipitation = precipitation
-        self.pressure = pressure
-        self.wind_speed = wind_speed
-        self.wind_bearing = wind_bearing
-        self.wind_gust_speed = wind_gust_speed
-        self.humidity = humidity
-        self.clouds = clouds
+	def __init__(
+		self,
+		forecast_datetime: datetime,
+		condition: str,
+		temperature: float,
+		apparent_temperature: float,
+		precipitation: float,
+		pressure: float,
+		wind_speed: float,
+		wind_bearing: float,
+		wind_gust_speed: float,
+		humidity: float,
+		clouds: float,
+	) -> None:
+		self.datetime = forecast_datetime
+		self.condition = condition
+		self.temperature = temperature
+		self.apparent_temperature = apparent_temperature
+		self.precipitation = precipitation
+		self.pressure = pressure
+		self.wind_speed = wind_speed
+		self.wind_bearing = wind_bearing
+		self.wind_gust_speed = wind_gust_speed
+		self.humidity = humidity
+		self.clouds = clouds
 
 
 class AladinWeather:
 
-    def __init__(self, actual_weather: AladinActualWeather) -> None:
-        self.actual_weather: AladinActualWeather = actual_weather
-        self.hourly_forecasts: List[AladinWeatherForecast] = []
+	def __init__(self, actual_weather: AladinActualWeather) -> None:
+		self.actual_weather: AladinActualWeather = actual_weather
+		self.hourly_forecasts: List[AladinWeatherForecast] = []
 
-    def add_hourly_forecast(self, forecast: AladinWeatherForecast) -> None:
-        self.hourly_forecasts.append(forecast)
+	def add_hourly_forecast(self, forecast: AladinWeatherForecast) -> None:
+		self.hourly_forecasts.append(forecast)
 
 
 class AladinOnlineCoordinator(DataUpdateCoordinator):
 
-    def __init__(self, hass: core.HomeAssistant, config: MappingProxyType) -> None:
-        super().__init__(hass, LOGGER, name=DOMAIN, update_interval=timedelta(minutes=30), update_method=self.update)
+	def __init__(self, hass: core.HomeAssistant, config: MappingProxyType) -> None:
+		super().__init__(hass, LOGGER, name=DOMAIN, update_interval=timedelta(minutes=30), update_method=self.update)
 
-        self._config: MappingProxyType = config
-        self._data = None
+		self._config: MappingProxyType = config
+		self._data = None
 
-    async def update(self) -> AladinWeather:
-        if self._should_update_data():
-            try:
-                await self._update_data()
-            except Exception as ex:
-                if self._data is None:
-                    raise ex
+	async def update(self) -> AladinWeather:
+		if self._should_update_data():
+			try:
+				await self._update_data()
+			except Exception as ex:
+				if self._data is None:
+					raise ex
 
-        if self._data is None:
-            raise ServiceUnavailable
+		if self._data is None:
+			raise ServiceUnavailable
 
-        entries = self._data.get("data", [])
-        if not entries:
-            raise NoData
+		entries = self._data.get("data", [])
+		if not entries:
+			raise NoData
 
-        now = datetime.now(tz=dt.UTC)
+		now = datetime.now(tz=dt.UTC)
 
-        # Najdi aktuální hodinu v datech
-        actual_entry = None
-        actual_index = 0
-        for i, entry in enumerate(entries):
-            entry_time = dt.parse_datetime(entry["validityTime"])
-            if entry_time <= now:
-                actual_entry = entry
-                actual_index = i
-            else:
-                break
+		# Najdi aktuální hodinu v datech
+		actual_entry = None
+		actual_index = 0
+		for i, entry in enumerate(entries):
+			entry_time = dt.parse_datetime(entry["validityTime"])
+			if entry_time <= now:
+				actual_entry = entry
+				actual_index = i
+			else:
+				break
 
-        if actual_entry is None:
-            actual_entry = entries[0]
-            actual_index = 0
+		if actual_entry is None:
+			actual_entry = entries[0]
+			actual_index = 0
 
-        actual_weather = AladinActualWeather(
-            condition=AladinOnlineCoordinator._format_condition(actual_entry.get("icon", 0)),
-            temperature=actual_entry.get("t2m"),
-            apparent_temperature=actual_entry.get("t2m"),   # nové API apparent_temp nemá, fallback na t2m
-            precipitation=actual_entry.get("prec", 0),
-            pressure=actual_entry.get("mslp"),              # už v hPa, nepřepočítávat
-            humidity=actual_entry.get("rh2m"),              # už v %, nepřepočítávat
-            clouds=actual_entry.get("cloudsTot"),            # už v %, nepřepočítávat
-            wind_speed=actual_entry.get("windSpeed", 0),
-            wind_bearing=AladinOnlineCoordinator._format_wind_direction(actual_entry.get("windDirection", 0)),
-            wind_gust_speed=actual_entry.get("windGustSpeed", 0),
-            wind_gust_bearing=AladinOnlineCoordinator._format_wind_direction(actual_entry.get("windDirection", 0)),
-            snow_precipitation=actual_entry.get("snow", 0),
-        )
+		actual_weather = AladinActualWeather(
+			condition=AladinOnlineCoordinator._format_condition(actual_entry.get("icon", 0)),
+			temperature=actual_entry.get("t2m"),
+			apparent_temperature=actual_entry.get("t2m"),   # nové API apparent_temp nemá, fallback na t2m
+			precipitation=actual_entry.get("prec", 0),
+			pressure=actual_entry.get("mslp"),              # už v hPa, nepřepočítávat
+			humidity=actual_entry.get("rh2m"),              # už v %, nepřepočítávat
+			clouds=actual_entry.get("cloudsTot"),            # už v %, nepřepočítávat
+			wind_speed=actual_entry.get("windSpeed", 0),
+			wind_bearing=AladinOnlineCoordinator._format_wind_direction(actual_entry.get("windDirection", 0)),
+			wind_gust_speed=actual_entry.get("windGustSpeed", 0),
+			wind_gust_bearing=AladinOnlineCoordinator._format_wind_direction(actual_entry.get("windDirection", 0)),
+			snow_precipitation=actual_entry.get("snow", 0),
+		)
 
-        weather = AladinWeather(actual_weather)
+		weather = AladinWeather(actual_weather)
 
-        for entry in entries[actual_index + 1:]:
-            forecast_datetime = dt.parse_datetime(entry["validityTime"])
+		for entry in entries[actual_index + 1:]:
+			forecast_datetime = dt.parse_datetime(entry["validityTime"])
 
-            forecast = AladinWeatherForecast(
-                forecast_datetime=forecast_datetime,
-                condition=AladinOnlineCoordinator._format_condition(entry.get("icon", 0)),
-                temperature=entry.get("t2m"),
-                apparent_temperature=entry.get("t2m"),
-                precipitation=entry.get("prec", 0),
-                pressure=entry.get("mslp"),
-                wind_speed=entry.get("windSpeed", 0),
-                wind_bearing=AladinOnlineCoordinator._format_wind_direction(entry.get("windDirection", 0)),
-                wind_gust_speed=entry.get("windGustSpeed", 0),
-                humidity=entry.get("rh2m"),
-                clouds=entry.get("cloudsTot"),
-            )
-            weather.add_hourly_forecast(forecast)
+			forecast = AladinWeatherForecast(
+				forecast_datetime=forecast_datetime,
+				condition=AladinOnlineCoordinator._format_condition(entry.get("icon", 0)),
+				temperature=entry.get("t2m"),
+				apparent_temperature=entry.get("t2m"),
+				precipitation=entry.get("prec", 0),
+				pressure=entry.get("mslp"),
+				wind_speed=entry.get("windSpeed", 0),
+				wind_bearing=AladinOnlineCoordinator._format_wind_direction(entry.get("windDirection", 0)),
+				wind_gust_speed=entry.get("windGustSpeed", 0),
+				humidity=entry.get("rh2m"),
+				clouds=entry.get("cloudsTot"),
+			)
+			weather.add_hourly_forecast(forecast)
 
-        return weather
+		return weather
 
-    def _should_update_data(self) -> bool:
-        if self._data is None:
-            return True
-        # ČHMÚ aktualizuje 4x denně: 00, 06, 12, 18 UTC
-        if datetime.now().hour in [1, 7, 13, 19]:
-            return True
-        return False
+	def _should_update_data(self) -> bool:
+		if self._data is None:
+			return True
+		# ČHMÚ aktualizuje 4x denně: 00, 06, 12, 18 UTC
+		if datetime.now().hour in [1, 7, 13, 19]:
+			return True
+		return False
 
-    async def _update_data(self) -> None:
-        session = aiohttp_client.async_get_clientsession(self.hass)
-        station_id = self._config.get(CONF_STATION_ID, 98)
-        response = await session.get(URL.format(station_id))
+	async def _update_data(self) -> None:
+		session = aiohttp_client.async_get_clientsession(self.hass)
+		station_id = self._config.get(CONF_STATION_ID, 98)
+		response = await session.get(URL.format(station_id))
 
-        if response.status != HTTPStatus.OK:
-            raise ServiceUnavailable
+		if response.status != HTTPStatus.OK:
+			raise ServiceUnavailable
 
-        self._data = await response.json(content_type=None)
+		self._data = await response.json(content_type=None)
 
-    @staticmethod
-    def _format_condition(icon: int) -> str:
-        if icon in ICON_CONDITION_MAP:
-            return ICON_CONDITION_MAP[icon]
-        LOGGER.warning("Neznámá ikona počasí: {}".format(icon))
-        return ATTR_CONDITION_SUNNY
+	@staticmethod
+	def _format_condition(icon: int) -> str:
+		if icon in ICON_CONDITION_MAP:
+			return ICON_CONDITION_MAP[icon]
+		LOGGER.warning("Neznámá ikona počasí: {}".format(icon))
+		return ATTR_CONDITION_SUNNY
 
-    @staticmethod
-    def _format_wind_direction(raw: float) -> float:
-        return (raw + 180) % 360
+	@staticmethod
+	def _format_wind_direction(raw: float) -> float:
+		return (raw + 180) % 360

--- a/custom_components/aladin_online/aladin_online.py
+++ b/custom_components/aladin_online/aladin_online.py
@@ -1,17 +1,18 @@
 from datetime import datetime, timedelta
 from homeassistant import core
 from homeassistant.components.weather import (
-	ATTR_CONDITION_CLEAR_NIGHT,
-	ATTR_CONDITION_CLOUDY,
-	ATTR_CONDITION_PARTLYCLOUDY,
-	ATTR_CONDITION_POURING,
-	ATTR_CONDITION_SNOWY,
-	ATTR_CONDITION_SUNNY,
-	ATTR_CONDITION_RAINY,
+    ATTR_CONDITION_CLEAR_NIGHT,
+    ATTR_CONDITION_CLOUDY,
+    ATTR_CONDITION_PARTLYCLOUDY,
+    ATTR_CONDITION_POURING,
+    ATTR_CONDITION_SNOWY,
+    ATTR_CONDITION_SUNNY,
+    ATTR_CONDITION_RAINY,
+    ATTR_CONDITION_WINDY,
 )
 from homeassistant.const import (
-	CONF_LATITUDE,
-	CONF_LONGITUDE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
 )
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -19,241 +20,210 @@ from homeassistant.util import dt
 from http import HTTPStatus
 import math
 from .const import (
-	DOMAIN,
-	LOGGER,
-	URL,
+    DOMAIN,
+    LOGGER,
+    CONF_STATION_ID,
+    URL,
 )
 from .errors import NoData, ServiceUnavailable
 from types import MappingProxyType
 from typing import Final, List
 
-DATA_TIME: Final = "forecastTimeIso"
-DATA_FORECAST_LENGTH: Final = "forecastLength"
-DATA_PARAMETERS: Final = "parameterValues"
-DATA_CONDITIONS: Final = "weatherIconNames"
-DATA_PARAMETER_CLOUDS: Final = "CLOUDS_TOTAL"
-DATA_PARAMETER_HUMIDITY: Final = "HUMIDITY"
-DATA_PARAMETER_PRECIPITATION: Final = "PRECIPITATION_TOTAL"
-DATA_PARAMETER_PRESSURE: Final = "PRESSURE"
-DATA_PARAMETER_SNOW_PRECIPITATION: Final = "PRECIPITATION_SNOW"
-DATA_PARAMETER_TEMPERATURE: Final = "TEMPERATURE"
-DATA_PARAMETER_APPARENT_TEMPERATURE: Final = "APPARENT_TEMPERATURE"
-DATA_PARAMETER_WIND_DIRECTION: Final = "WIND_DIRECTION"
-DATA_PARAMETER_WIND_SPEED: Final = "WIND_SPEED"
-DATA_PARAMETER_WIND_GUST_SPEED: Final = "WIND_GUST_SPEED"
-DATA_PARAMETER_WIND_GUST_DIRECTION: Final = "WIND_GUST_DIRECTION"
+# Nová URL - data-provider.chmi.cz, parametr je ID stanice
+URL: Final = "https://data-provider.chmi.cz/api/graphs/graf.meteogram/{}"
+
+# Mapování číselných ikon na HA podmínky
+# Vzor: 10=jasno den, 110=jasno noc, 20=skoro jasno den, 120=skoro jasno noc
+# 40=polojasno, 140=polojasno noc, 60=skoro zataženo, 70=zataženo+déšť
+# 80=zataženo, 81=zataženo+déšť, 160=polojasno noc, 170=skoro zataženo noc
+ICON_CONDITION_MAP = {
+    10:  ATTR_CONDITION_SUNNY,          # jasno den
+    20:  ATTR_CONDITION_SUNNY,          # skoro jasno den
+    40:  ATTR_CONDITION_PARTLYCLOUDY,   # polojasno
+    60:  ATTR_CONDITION_CLOUDY,         # skoro zataženo
+    70:  ATTR_CONDITION_RAINY,          # zataženo + déšť
+    80:  ATTR_CONDITION_CLOUDY,         # zataženo
+    81:  ATTR_CONDITION_POURING,        # zataženo + silný déšť
+    110: ATTR_CONDITION_CLEAR_NIGHT,    # jasno noc
+    120: ATTR_CONDITION_CLEAR_NIGHT,    # skoro jasno noc
+    140: ATTR_CONDITION_PARTLYCLOUDY,   # polojasno noc
+    160: ATTR_CONDITION_PARTLYCLOUDY,   # skoro zataženo noc
+    170: ATTR_CONDITION_CLOUDY,         # zataženo noc
+}
 
 
 class AladinActualWeather:
 
-	def __init__(
-		self,
-		condition: str,
-		temperature: float,
-		apparent_temperature: float,
-		precipitation: float,
-		pressure: float,
-		humidity: float,
-		clouds: float,
-		wind_speed: float,
-		wind_bearing: float,
-		wind_gust_speed: float,
-		wind_gust_bearing: float,
-		snow_precipitation: float,
-	) -> None:
-		self.condition = condition
-		self.temperature = temperature
-		self.apparent_temperature = apparent_temperature
-		self.precipitation = precipitation
-		self.pressure = pressure
-		self.humidity = humidity
-		self.clouds = clouds
-		self.wind_speed = wind_speed
-		self.wind_bearing = wind_bearing
-		self.wind_gust_speed = wind_gust_speed
-		self.wind_gust_bearing = wind_gust_bearing
-		self.snow_precipitation = snow_precipitation
+    def __init__(
+        self,
+        condition: str,
+        temperature: float,
+        apparent_temperature: float,
+        precipitation: float,
+        pressure: float,
+        humidity: float,
+        clouds: float,
+        wind_speed: float,
+        wind_bearing: float,
+        wind_gust_speed: float,
+        wind_gust_bearing: float,
+        snow_precipitation: float,
+    ) -> None:
+        self.condition = condition
+        self.temperature = temperature
+        self.apparent_temperature = apparent_temperature
+        self.precipitation = precipitation
+        self.pressure = pressure
+        self.humidity = humidity
+        self.clouds = clouds
+        self.wind_speed = wind_speed
+        self.wind_bearing = wind_bearing
+        self.wind_gust_speed = wind_gust_speed
+        self.wind_gust_bearing = wind_gust_bearing
+        self.snow_precipitation = snow_precipitation
 
 
 class AladinWeatherForecast:
 
-	def __init__(
-		self,
-		forecast_datetime: datetime,
-		condition: str,
-		temperature: float,
-		apparent_temperature: float,
-		precipitation: float,
-		pressure: float,
-		wind_speed: float,
-		wind_bearing: float,
-		wind_gust_speed: float,
-		humidity: float,
-		clouds: float,
-	) -> None:
-		self.datetime = forecast_datetime
-		self.condition = condition
-		self.temperature = temperature
-		self.apparent_temperature = apparent_temperature
-		self.precipitation = precipitation
-		self.pressure = pressure
-		self.wind_speed = wind_speed
-		self.wind_bearing = wind_bearing
-		self.wind_gust_speed = wind_gust_speed
-		self.humidity = humidity
-		self.clouds = clouds
+    def __init__(
+        self,
+        forecast_datetime: datetime,
+        condition: str,
+        temperature: float,
+        apparent_temperature: float,
+        precipitation: float,
+        pressure: float,
+        wind_speed: float,
+        wind_bearing: float,
+        wind_gust_speed: float,
+        humidity: float,
+        clouds: float,
+    ) -> None:
+        self.datetime = forecast_datetime
+        self.condition = condition
+        self.temperature = temperature
+        self.apparent_temperature = apparent_temperature
+        self.precipitation = precipitation
+        self.pressure = pressure
+        self.wind_speed = wind_speed
+        self.wind_bearing = wind_bearing
+        self.wind_gust_speed = wind_gust_speed
+        self.humidity = humidity
+        self.clouds = clouds
+
 
 class AladinWeather:
 
-	def __init__(self, actual_weather: AladinActualWeather) -> None:
-		self.actual_weather: AladinActualWeather = actual_weather
-		self.hourly_forecasts: List[AladinWeatherForecast] = []
+    def __init__(self, actual_weather: AladinActualWeather) -> None:
+        self.actual_weather: AladinActualWeather = actual_weather
+        self.hourly_forecasts: List[AladinWeatherForecast] = []
 
-	def add_hourly_forecast(self, forecast: AladinWeatherForecast) -> None:
-		self.hourly_forecasts.append(forecast)
+    def add_hourly_forecast(self, forecast: AladinWeatherForecast) -> None:
+        self.hourly_forecasts.append(forecast)
 
 
 class AladinOnlineCoordinator(DataUpdateCoordinator):
 
-	def __init__(self, hass: core.HomeAssistant, config: MappingProxyType) -> None:
-		super().__init__(hass, LOGGER, name=DOMAIN, update_interval=timedelta(minutes=1), update_method=self.update)
+    def __init__(self, hass: core.HomeAssistant, config: MappingProxyType) -> None:
+        super().__init__(hass, LOGGER, name=DOMAIN, update_interval=timedelta(minutes=30), update_method=self.update)
 
-		self._config: MappingProxyType = config
+        self._config: MappingProxyType = config
+        self._data = None
 
-		self._data = None
+    async def update(self) -> AladinWeather:
+        if self._should_update_data():
+            try:
+                await self._update_data()
+            except Exception as ex:
+                if self._data is None:
+                    raise ex
 
-	async def update(self) -> AladinWeather:
-		if self._should_update_data():
-			try:
-				await self._update_data()
-			except Exception as ex:
-				if self._data is None:
-					raise ex
+        if self._data is None:
+            raise ServiceUnavailable
 
-		if self._data is None:
-			raise ServiceUnavailable
+        entries = self._data.get("data", [])
+        if not entries:
+            raise NoData
 
-		data_time = await AladinOnlineCoordinator._format_datetime(self._data[DATA_TIME])
-		now = datetime.now()
+        now = datetime.now(tz=dt.UTC)
 
-		actual_index = int(math.floor((now.timestamp() - data_time.timestamp()) / 3600))
-		condition_actual_index = int(math.floor(actual_index / 2))
+        # Najdi aktuální hodinu v datech
+        actual_entry = None
+        actual_index = 0
+        for i, entry in enumerate(entries):
+            entry_time = dt.parse_datetime(entry["validityTime"])
+            if entry_time <= now:
+                actual_entry = entry
+                actual_index = i
+            else:
+                break
 
-		parameters = self._data[DATA_PARAMETERS]
+        if actual_entry is None:
+            actual_entry = entries[0]
+            actual_index = 0
 
-		if condition_actual_index >= len(self._data[DATA_CONDITIONS]):
-			raise NoData
+        actual_weather = AladinActualWeather(
+            condition=AladinOnlineCoordinator._format_condition(actual_entry.get("icon", 0)),
+            temperature=actual_entry.get("t2m"),
+            apparent_temperature=actual_entry.get("t2m"),   # nové API apparent_temp nemá, fallback na t2m
+            precipitation=actual_entry.get("prec", 0),
+            pressure=actual_entry.get("mslp"),              # už v hPa, nepřepočítávat
+            humidity=actual_entry.get("rh2m"),              # už v %, nepřepočítávat
+            clouds=actual_entry.get("cloudsTot"),            # už v %, nepřepočítávat
+            wind_speed=actual_entry.get("windSpeed", 0),
+            wind_bearing=AladinOnlineCoordinator._format_wind_direction(actual_entry.get("windDirection", 0)),
+            wind_gust_speed=actual_entry.get("windGustSpeed", 0),
+            wind_gust_bearing=AladinOnlineCoordinator._format_wind_direction(actual_entry.get("windDirection", 0)),
+            snow_precipitation=actual_entry.get("snow", 0),
+        )
 
-		actual_weather = AladinActualWeather(
-			AladinOnlineCoordinator._format_condition(self._data[DATA_CONDITIONS][condition_actual_index]),
-			AladinOnlineCoordinator._format_temperature(parameters[DATA_PARAMETER_TEMPERATURE][actual_index]),
-			AladinOnlineCoordinator._format_temperature(parameters[DATA_PARAMETER_APPARENT_TEMPERATURE][actual_index]),
-			AladinOnlineCoordinator._format_precipitation(parameters[DATA_PARAMETER_PRECIPITATION][actual_index]),
-			AladinOnlineCoordinator._format_pressure(parameters[DATA_PARAMETER_PRESSURE][actual_index]),
-			AladinOnlineCoordinator._format_percent(parameters[DATA_PARAMETER_HUMIDITY][actual_index]),
-			AladinOnlineCoordinator._format_percent(parameters[DATA_PARAMETER_CLOUDS][actual_index]),
-			AladinOnlineCoordinator._format_wind_speed(parameters[DATA_PARAMETER_WIND_SPEED][actual_index]),
-			AladinOnlineCoordinator._format_wind_direction(parameters[DATA_PARAMETER_WIND_DIRECTION][actual_index]),
-			AladinOnlineCoordinator._format_wind_speed(parameters[DATA_PARAMETER_WIND_GUST_SPEED][actual_index]),
-			AladinOnlineCoordinator._format_wind_direction(parameters[DATA_PARAMETER_WIND_GUST_DIRECTION][actual_index]),
-			AladinOnlineCoordinator._format_precipitation(parameters[DATA_PARAMETER_SNOW_PRECIPITATION][actual_index]),
-		)
+        weather = AladinWeather(actual_weather)
 
-		weather = AladinWeather(actual_weather)
+        for entry in entries[actual_index + 1:]:
+            forecast_datetime = dt.parse_datetime(entry["validityTime"])
 
-		for i in range(actual_index + 1, self._data[DATA_FORECAST_LENGTH]):
-			forecast_datetime = data_time + timedelta(hours=i)
-			forecast_condition_index = int(math.floor(i / 2))
+            forecast = AladinWeatherForecast(
+                forecast_datetime=forecast_datetime,
+                condition=AladinOnlineCoordinator._format_condition(entry.get("icon", 0)),
+                temperature=entry.get("t2m"),
+                apparent_temperature=entry.get("t2m"),
+                precipitation=entry.get("prec", 0),
+                pressure=entry.get("mslp"),
+                wind_speed=entry.get("windSpeed", 0),
+                wind_bearing=AladinOnlineCoordinator._format_wind_direction(entry.get("windDirection", 0)),
+                wind_gust_speed=entry.get("windGustSpeed", 0),
+                humidity=entry.get("rh2m"),
+                clouds=entry.get("cloudsTot"),
+            )
+            weather.add_hourly_forecast(forecast)
 
-			forecast = AladinWeatherForecast(
-				forecast_datetime,
-				AladinOnlineCoordinator._format_condition(self._data[DATA_CONDITIONS][forecast_condition_index]),
-				AladinOnlineCoordinator._format_temperature(parameters[DATA_PARAMETER_TEMPERATURE][i]),
-				AladinOnlineCoordinator._format_temperature(parameters[DATA_PARAMETER_APPARENT_TEMPERATURE][i]),
-				AladinOnlineCoordinator._format_precipitation(parameters[DATA_PARAMETER_PRECIPITATION][i]),
-				AladinOnlineCoordinator._format_pressure(parameters[DATA_PARAMETER_PRESSURE][i]),
-				AladinOnlineCoordinator._format_wind_speed(parameters[DATA_PARAMETER_WIND_SPEED][i]),
-				AladinOnlineCoordinator._format_wind_direction(parameters[DATA_PARAMETER_WIND_DIRECTION][i]),
-				AladinOnlineCoordinator._format_wind_speed(parameters[DATA_PARAMETER_WIND_GUST_SPEED][i]),
-				AladinOnlineCoordinator._format_percent(parameters[DATA_PARAMETER_HUMIDITY][i]),
-				AladinOnlineCoordinator._format_percent(parameters[DATA_PARAMETER_CLOUDS][i]),
-			)
+        return weather
 
-			weather.add_hourly_forecast(forecast)
+    def _should_update_data(self) -> bool:
+        if self._data is None:
+            return True
+        # ČHMÚ aktualizuje 4x denně: 00, 06, 12, 18 UTC
+        if datetime.now().hour in [1, 7, 13, 19]:
+            return True
+        return False
 
-		return weather
+    async def _update_data(self) -> None:
+        session = aiohttp_client.async_get_clientsession(self.hass)
+        station_id = self._config.get(CONF_STATION_ID, 98)
+        response = await session.get(URL.format(station_id))
 
-	def _should_update_data(self) -> bool:
-		if self._data is None:
-			return True
+        if response.status != HTTPStatus.OK:
+            raise ServiceUnavailable
 
-		# Updates are in 0, 5, 12 and 17 hour so wait an hour to be sure the update is there
-		if datetime.now().hour in [1, 6, 13, 18]:
-			return True
+        self._data = await response.json(content_type=None)
 
-		return False
+    @staticmethod
+    def _format_condition(icon: int) -> str:
+        if icon in ICON_CONDITION_MAP:
+            return ICON_CONDITION_MAP[icon]
+        LOGGER.warning("Neznámá ikona počasí: {}".format(icon))
+        return ATTR_CONDITION_SUNNY
 
-	async def _update_data(self) -> None:
-		session = aiohttp_client.async_get_clientsession(self.hass)
-		response = await session.get(URL.format(self._config[CONF_LATITUDE], self._config[CONF_LONGITUDE]))
-
-		if response.status != HTTPStatus.OK:
-			raise ServiceUnavailable
-
-		# The URL returns "text/html" so ignore content_type check
-		self._data = await response.json(content_type=None)
-
-	@staticmethod
-	async def _format_datetime(raw: str) -> datetime:
-		# The time is in UTC
-		return dt.parse_datetime(raw)
-
-	@staticmethod
-	def _format_condition(raw: str) -> str:
-		mapping = {
-			"wi_cloud_snow_heavy": ATTR_CONDITION_SNOWY,
-			"wi_cloud_snow_medium": ATTR_CONDITION_SNOWY,
-			"wi_cloud_snow_light": ATTR_CONDITION_SNOWY,
-			"wi_night_cloud_snow": ATTR_CONDITION_SNOWY,
-			"wi_day_cloud_snow": ATTR_CONDITION_SNOWY,
-			"wi_day_cloud_rain": ATTR_CONDITION_RAINY,
-			"wi_night_cloud_rain": ATTR_CONDITION_RAINY,
-			"wi_cloud_rain_heavy": ATTR_CONDITION_RAINY,
-			"wi_cloud_rain_medium": ATTR_CONDITION_RAINY,
-			"wi_cloud_rain_light": ATTR_CONDITION_POURING,
-			"wi_cloud": ATTR_CONDITION_CLOUDY,
-			"wi_night_cloud": ATTR_CONDITION_PARTLYCLOUDY,
-			"wi_day_cloud": ATTR_CONDITION_PARTLYCLOUDY,
-			"wi_night": ATTR_CONDITION_CLEAR_NIGHT,
-			"wi_day": ATTR_CONDITION_SUNNY,
-		}
-
-		if raw in mapping:
-			return mapping[raw]
-
-		LOGGER.error("Unknown condition: {}".format(raw))
-		return ATTR_CONDITION_SUNNY
-
-	@staticmethod
-	def _format_temperature(raw: float) -> float:
-		return raw
-
-	@staticmethod
-	def _format_percent(raw: float) -> float:
-		return raw * 100
-
-	@staticmethod
-	def _format_precipitation(raw: float) -> float:
-		return abs(raw)
-
-	@staticmethod
-	def _format_pressure(raw: float) -> float:
-		return raw / 100
-
-	@staticmethod
-	def _format_wind_speed(raw: float) -> float:
-		return raw
-
-	@staticmethod
-	def _format_wind_direction(raw: float) -> float:
-		return (raw + 180) % 360
+    @staticmethod
+    def _format_wind_direction(raw: float) -> float:
+        return (raw + 180) % 360

--- a/custom_components/aladin_online/config_flow.py
+++ b/custom_components/aladin_online/config_flow.py
@@ -11,38 +11,38 @@ from .errors import ServiceUnavailable
 from typing import Any, Dict
 
 class AladinOnlineConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Weather forecast config flow."""
+	"""Weather forecast config flow."""
 
-    async def async_step_user(self, user_input: Dict[str, Any] | None = None) -> FlowResult:
-        errors = {}
-        if user_input is not None:
-            try:
-                config = {
-                    CONF_NAME: user_input[CONF_NAME],
-                    CONF_STATION_ID: user_input[CONF_STATION_ID],
-                }
-                await self.async_set_unique_id(user_input[CONF_NAME])
-                self._abort_if_unique_id_configured()
+	async def async_step_user(self, user_input: Dict[str, Any] | None = None) -> FlowResult:
+		errors = {}
+		if user_input is not None:
+			try:
+				config = {
+					CONF_NAME: user_input[CONF_NAME],
+					CONF_STATION_ID: user_input[CONF_STATION_ID],
+				}
+				await self.async_set_unique_id(user_input[CONF_NAME])
+				self._abort_if_unique_id_configured()
 
-                session = aiohttp_client.async_get_clientsession(self.hass)
-                response = await session.get(URL.format(user_input[CONF_STATION_ID]))
-                if response.status != HTTPStatus.OK:
-                    raise ServiceUnavailable
+				session = aiohttp_client.async_get_clientsession(self.hass)
+				response = await session.get(URL.format(user_input[CONF_STATION_ID]))
+				if response.status != HTTPStatus.OK:
+					raise ServiceUnavailable
 
-                return self.async_create_entry(title=NAME, data=config)
-            except AbortFlow as ex:
-                return self.async_abort(reason=ex.reason)
-            except ServiceUnavailable:
-                errors["base"] = "service_unavailable"
-            except Exception:
-                LOGGER.error("Unknown error connecting to %s", URL.format(user_input[CONF_STATION_ID]))
-                return self.async_abort(reason="unknown")
+				return self.async_create_entry(title=NAME, data=config)
+			except AbortFlow as ex:
+				return self.async_abort(reason=ex.reason)
+			except ServiceUnavailable:
+				errors["base"] = "service_unavailable"
+			except Exception:
+				LOGGER.error("Unknown error connecting to %s", URL.format(user_input[CONF_STATION_ID]))
+				return self.async_abort(reason="unknown")
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema({
-                vol.Required(CONF_NAME, default=self.hass.config.location_name): str,
-                vol.Required(CONF_STATION_ID, default=98): int,
-            }),
-            errors=errors,
-        )
+		return self.async_show_form(
+			step_id="user",
+			data_schema=vol.Schema({
+				vol.Required(CONF_NAME, default=self.hass.config.location_name): str,
+				vol.Required(CONF_STATION_ID, default=98): int,
+			}),
+			errors=errors,
+		)

--- a/custom_components/aladin_online/config_flow.py
+++ b/custom_components/aladin_online/config_flow.py
@@ -1,84 +1,48 @@
 from __future__ import annotations
 from homeassistant import config_entries
-from homeassistant.const import (
-	CONF_NAME,
-	CONF_LATITUDE,
-	CONF_LONGITUDE,
-)
+from homeassistant.const import CONF_NAME
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import aiohttp_client
 from http import HTTPStatus
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from .const import (
-	DOMAIN,
-	NAME,
-	URL,
-	LOGGER,
-)
-from .errors import LocationUnavailable, ServiceUnavailable
+from .const import DOMAIN, NAME, URL, LOGGER, CONF_STATION_ID
+from .errors import ServiceUnavailable
 from typing import Any, Dict
 
-
 class AladinOnlineConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-	"""Weather forecast config flow."""
+    """Weather forecast config flow."""
 
-	async def async_step_user(self, user_input: Dict[str, Any] | None = None) -> FlowResult:
-		"""Handle a config flow initialized by the user."""
-		errors = {}
+    async def async_step_user(self, user_input: Dict[str, Any] | None = None) -> FlowResult:
+        errors = {}
+        if user_input is not None:
+            try:
+                config = {
+                    CONF_NAME: user_input[CONF_NAME],
+                    CONF_STATION_ID: user_input[CONF_STATION_ID],
+                }
+                await self.async_set_unique_id(user_input[CONF_NAME])
+                self._abort_if_unique_id_configured()
 
-		if user_input is not None:
+                session = aiohttp_client.async_get_clientsession(self.hass)
+                response = await session.get(URL.format(user_input[CONF_STATION_ID]))
+                if response.status != HTTPStatus.OK:
+                    raise ServiceUnavailable
 
-			try:
-				config = {
-					CONF_NAME: user_input[CONF_NAME],
-					CONF_LATITUDE: user_input[CONF_LATITUDE],
-					CONF_LONGITUDE: user_input[CONF_LONGITUDE],
-				}
+                return self.async_create_entry(title=NAME, data=config)
+            except AbortFlow as ex:
+                return self.async_abort(reason=ex.reason)
+            except ServiceUnavailable:
+                errors["base"] = "service_unavailable"
+            except Exception:
+                LOGGER.error("Unknown error connecting to %s", URL.format(user_input[CONF_STATION_ID]))
+                return self.async_abort(reason="unknown")
 
-				unique_id = user_input[CONF_NAME]
-
-				await self.async_set_unique_id(unique_id)
-				self._abort_if_unique_id_configured()
-
-				session = aiohttp_client.async_get_clientsession(self.hass)
-				response = await session.get(URL.format(config[CONF_LATITUDE], config[CONF_LONGITUDE]))
-
-				if response.status != HTTPStatus.OK:
-					raise ServiceUnavailable
-
-				text = await response.text()
-
-				if text == "":
-					raise LocationUnavailable
-
-				return self.async_create_entry(title=NAME, data=config)
-
-			except AbortFlow as ex:
-				return self.async_abort(reason=ex.reason)
-
-			except ServiceUnavailable:
-				errors["base"] = "service_unavailable"
-
-			except LocationUnavailable:
-				errors["base"] = "location_unavailable"
-
-			except Exception:
-				LOGGER.error(
-					"Unknown error connecting to %s",
-					URL.format(user_input[CONF_LATITUDE], user_input[CONF_LONGITUDE]),
-				)
-
-				return self.async_abort(reason="unknown")
-
-		return self.async_show_form(
-			step_id="user",
-			data_schema=vol.Schema(
-				{
-					vol.Required(CONF_NAME, default=self.hass.config.location_name): str,
-					vol.Required(CONF_LATITUDE, default=self.hass.config.latitude): cv.latitude,
-					vol.Required(CONF_LONGITUDE, default=self.hass.config.longitude): cv.longitude,
-				}
-			),
-			errors=errors,
-		)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({
+                vol.Required(CONF_NAME, default=self.hass.config.location_name): str,
+                vol.Required(CONF_STATION_ID, default=98): int,
+            }),
+            errors=errors,
+        )

--- a/custom_components/aladin_online/const.py
+++ b/custom_components/aladin_online/const.py
@@ -2,7 +2,7 @@ import logging
 from typing import Final
 
 LOGGER: Final = logging.getLogger(__package__)
-
 DOMAIN: Final = "aladin_online"
-NAME: Final = "Aladin online (Czech Republic)"
-URL: Final = "https://aladinonline.oblacno.cz/get_data.php?latitude={}&longitude={}"
+NAME: Final = "Aladin online EK (Czech Republic)"
+URL: Final = "https://data-provider.chmi.cz/api/graphs/graf.meteogram/{}"
+CONF_STATION_ID: Final = "station_id"

--- a/custom_components/aladin_online/sensor.py
+++ b/custom_components/aladin_online/sensor.py
@@ -152,7 +152,7 @@ class SensorEntity(CoordinatorEntity, ComponentSensorEntity):
 		)
 
 		self._attr_device_info = DeviceInfo(
-			identifiers={(DOMAIN,)},
+			identifiers={(DOMAIN, config[CONF_NAME])},
 			model="Weather forecast",
 			name=config[CONF_NAME],
 			manufacturer=NAME,

--- a/custom_components/aladin_online/strings.json
+++ b/custom_components/aladin_online/strings.json
@@ -3,17 +3,16 @@
 		"step": {
 			"user": {
 				"title": "Aladin online (Czech Republic)",
-				"data": {
-					"name": "Name",
-					"latitude": "Latitude",
-					"longitude": "Longitude"
-				}
+			"data": {
+				"name": "Name",
+				"station_id": "Station ID"
+			}
 			}
 		},
 		"abort": {
 			"already_configured": "Aladin online for this name is already configured.",
 			"service_unavailable": "Service is not available.",
-			"location_unavailable": "Location is not available."
+			"unknown": "Unknown error connecting to the service."
 		}
 	},
 	"entity": {

--- a/custom_components/aladin_online/translations/cs.json
+++ b/custom_components/aladin_online/translations/cs.json
@@ -5,15 +5,14 @@
 				"title": "Aladin online (Česká republika)",
 				"data": {
 					"name": "Název",
-					"latitude": "Zeměpisná šířka",
-					"longitude": "Zeměpisná délka"
+					"station_id": "ID stanice"
 				}
 			}
 		},
 		"abort": {
 			"already_configured": "Aladin online pro tento název je již nastaven.",
 			"service_unavailable": "Služba není dostupná.",
-			"location_unavailable": "Lokace není dostupná."
+			"unknown": "Neznámá chyba při připojování ke službě."
 		}
 	},
 	"entity": {
@@ -46,4 +45,5 @@
 				"name": "Nárazová rychlost větru"
 			}
 		}
-	}}
+	}
+}

--- a/custom_components/aladin_online/weather.py
+++ b/custom_components/aladin_online/weather.py
@@ -64,7 +64,7 @@ class WeatherEntity(CoordinatorEntity, ComponentWeatherEntity):
 		)
 
 		self._attr_device_info = DeviceInfo(
-			identifiers={(DOMAIN,)},
+			identifiers={(DOMAIN, config[CONF_NAME])},
 			model="Weather forecast",
 			name=config[CONF_NAME],
 			manufacturer=NAME,


### PR DESCRIPTION
## Problem

The integration stopped working because ČHMÚ (Czech Hydrometeorological Institute) 
migrated their web infrastructure in December 2025. Since January/February 2026 they 
have been shutting down the old system at `intranet.chmi.cz`.

Both data sources the integration relied on are now offline:
- `aladinonline.androworks.org` — redirects to a parked/disabled hosting page
- old JSON endpoint at `intranet.chmi.cz` — no longer exists

Fixes #24

## Solution

ČHMÚ now provides forecast data via a new API at `data-provider.chmi.cz`.
The new endpoint serves hourly forecast data per weather station ID:
GET https://data-provider.chmi.cz/api/graphs/graf.meteogram/{station_id}

Station IDs can be found in the URL when browsing meteograms on the new ČHMÚ website,
e.g. `https://www.chmi.cz/meteogram/98-dubnany` → station ID is `98`.

## Breaking changes

The integration no longer accepts latitude/longitude in the config flow.
Instead, the user provides a **station ID** (integer).

Existing installations need to be **re-added** after updating.

## Changes

- `const.py` — new API URL, added `CONF_STATION_ID`, removed lat/lon
- `config_flow.py` — config form now asks for station ID instead of coordinates
- `aladin_online.py` — rewritten data parser for new API response format

## New API response format

```json
{
  "data": [
    {
      "validityTime": "2026-06-08T00:00:00+00:00",
      "t2m": 13.8,
      "rh2m": 79,
      "prec": 0,
      "windGustSpeed": 0,
      "windSpeed": 2.6,
      "windDirection": 53,
      "icon": 110,
      "mslp": 1022.3,
      "snow": 0,
      "cloudsTot": 0
    }
  ]
}
```

Note: `mslp`, `rh2m` and `cloudsTot` are already in correct units (hPa, %, %)
— no conversion needed unlike the old API.